### PR TITLE
Adding class 'fetti'

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -11,7 +11,7 @@ function createElements(root, elementCount) {
     .from({ length: elementCount })
     .map((_, index) => {
       const element = document.createElement('div');
-      element.classList = ['fetti'];
+      element.classList.add('fetti');
       const color = colors[index % colors.length];
       element.style['background-color']= color; // eslint-disable-line space-infix-ops
       element.style.width = '10px';


### PR DESCRIPTION
Thanks for this awesome component!

When trying to run this inside Firefox or IE11, it's complaining about the way ```classList``` is used. I think only Chrome and Safari know how to interpret classList as an Array.