### PR TITLE
Feature: Allow colours to be passed in along with configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dom-confetti",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "confetti with dom elements",
   "main": "lib/main.js",
   "scripts": {

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-const colors = [
+const defaultColors = [
   '#a864fd',
   '#29cdff',
   '#78ff44',
@@ -6,7 +6,7 @@ const colors = [
   '#fdff6a'
 ];
 
-function createElements(root, elementCount) {
+function createElements(root, elementCount, colors) {
   return Array
     .from({ length: elementCount })
     .map((_, index) => {
@@ -80,9 +80,10 @@ export function confetti(root, {
     decay = 0.9,
     spread = 45,
     startVelocity = 45,
-    elementCount = 50
+    elementCount = 50,
+    colors = defaultColors
   } = {}) {
-  const elements = createElements(root, elementCount);
+  const elements = createElements(root, elementCount, colors);
   const fettis = elements.map((element) => ({
     element,
     physics: randomPhysics(angle, spread, startVelocity)


### PR DESCRIPTION
Hey there, thanks for making this! Here's a simple change that allows the author's own range of colours to be passed in as an array, `colors` in the configuration object. 