### PR TITLE
Add confetti element size to configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This will trigger a confetti explosion every time a button is clicked.
 - `spread` - spread of the explosion in degrees,  deafults to 45.
 - `startVelocity` - Initial velocity of the particles, defaults to 45.
 - `elementCount` - Number of particle elements, default to 50.
+- `width`: - width of the confetti elements
+- `height`: - height of the confetti elements
+- `colors`: - array of possible colors of the elements
 - `decay` - Decrease in velocity per frame, defaults to 0.9
 - `random` - Randomization function, defaults to Math.random
 

--- a/src/main.js
+++ b/src/main.js
@@ -6,15 +6,15 @@ const defaultColors = [
   '#fdff6a'
 ];
 
-function createElements(root, elementCount, colors) {
+function createElements(root, elementCount, colors, width, height) {
   return Array
     .from({ length: elementCount })
     .map((_, index) => {
       const element = document.createElement('div');
       const color = colors[index % colors.length];
       element.style['background-color']= color; // eslint-disable-line space-infix-ops
-      element.style.width = '10px';
-      element.style.height = '10px';
+      element.style.width = width;
+      element.style.height = height;
       element.style.position = 'absolute';
       root.appendChild(element);
       return element;
@@ -84,10 +84,12 @@ export function confetti(root, {
     spread = 45,
     startVelocity = 45,
     elementCount = 50,
+    width = '10px',
+    height = '10px',
     colors = defaultColors,
     random = Math.random,
   } = {}) {
-  const elements = createElements(root, elementCount, colors);
+  const elements = createElements(root, elementCount, colors, width, height);
   const fettis = elements.map((element) => ({
     element,
     physics: randomPhysics(angle, spread, startVelocity, random)


### PR DESCRIPTION
I added the width and height of the confetti elements to the config object. Since the dimensions are assigned to the DOM, you can't change them even with the CSS.
I needed this feature in the library [daniel-lundin/react-dom-confetti](https://github.com/daniel-lundin/react-dom-confetti), so I'd like you to update that library too.