### PR TITLE
Fix Typescript definition for width/height

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 interface ConfettiConfig {
     angle?: number;
     spread?: number;
-    width?: number;
-    height?: number;
+    width?: string;
+    height?: string;
     duration?: number;
     dragFriction?: number;
     stagger?: number;


### PR DESCRIPTION
If you pass a number as width/height it doesn't work, as you need the `px` at the end for CSS to handle it properly.