### PR TITLE
Add contract to props to allow function to determine if/when an element should be removed

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -59,7 +59,7 @@ function updateFetti(fetti, progress, dragFriction, decay) {
   /* eslint-enable */
 }
 
-function animate(root, fettis, dragFriction, decay, duration, stagger) {
+function animate(root, fettis, dragFriction, decay, duration, stagger, shouldRenderElement) {
   let startTime;
 
   return new Promise(resolve => {
@@ -72,6 +72,19 @@ function animate(root, fettis, dragFriction, decay, duration, stagger) {
       });
 
       if (time - startTime < duration) {
+        if(shouldRenderElement){
+          // if the user has declared a custom function to state when
+          // a fetti should be rendered, use it
+
+          fettis.forEach(fetti => {
+            if(!shouldRenderElement(fetti.element)){
+              if(fetti.element.parentNode === root) { 
+                root.removeChild(fetti.element);
+              }
+            }
+          });  
+        }
+
         requestAnimationFrame(update);
       } else {
         fettis.forEach(fetti => {
@@ -99,7 +112,8 @@ const defaults = {
   duration: 3000,
   stagger: 0,
   dragFriction: 0.1,
-  random: Math.random
+  random: Math.random,
+  shouldRenderElement: null,
 };
 
 function backwardPatch(config) {
@@ -123,7 +137,8 @@ export function confetti(root, config = {}) {
     dragFriction,
     duration,
     stagger,
-    random
+    random,
+    shouldRenderElement
   } = Object.assign({}, defaults, backwardPatch(config));
   root.style.perspective = perspective;
   const elements = createElements(root, elementCount, colors, width, height);
@@ -132,5 +147,5 @@ export function confetti(root, config = {}) {
     physics: randomPhysics(angle, spread, startVelocity, random)
   }));
 
-  return animate(root, fettis, dragFriction, decay, duration, stagger);
+  return animate(root, fettis, dragFriction, decay, duration, stagger, shouldRenderElement);
 }

--- a/test/index.html
+++ b/test/index.html
@@ -31,6 +31,20 @@
     <script type="module">
       import { confetti } from '../src/main.js';
 
+      const isElementOnscreen = function(el) {
+        var rect = el.getBoundingClientRect();
+        const windowBufferPercentage = 0.025
+        const heightBuffer = window.innerHeight * windowBufferPercentage;
+        const widthBuffer = window.innerWidth * windowBufferPercentage;
+
+        return !(
+           (rect.x + rect.width) < widthBuffer
+             || (rect.y + rect.height) < heightBuffer
+             || (rect.x > window.innerWidth - widthBuffer
+             || rect.y > window.innerHeight - heightBuffer)
+          );
+      }
+
       function readFormValues() {
         const angle = document.getElementById('angle').value;
         const spread = document.getElementById('spread').value;
@@ -40,7 +54,7 @@
         const delay = parseFloat(document.getElementById('delay').value);
         const elementCount = parseFloat(document.getElementById('elements').value);
 
-        return { angle, spread, startVelocity, duration, dragFriction,delay, elementCount };
+        return { angle, spread, startVelocity, duration, dragFriction,delay, elementCount, shouldRenderElement: isElementOnscreen };
       }
 
       function init() {


### PR DESCRIPTION
This PR allows for a user to specify, as part of the config provided to the confetti function, a function which takes in an element, and determines whether that element should continue to be rendered.

By allowing a user to specify when a confetti element should be removed from the DOM, we can eliminate [this issue](https://github.com/daniel-lundin/dom-confetti/issues/34), by allowing them to provide a function to de-render the specific confetti element when it leaves the main screen region. In the case of the modified test/index.html, this function takes the confetti element's placement into account as compared to it's distance to the edge of the user window in order to determine if it should continue to have that confetti element be present.